### PR TITLE
change dead pycurl package download link

### DIFF
--- a/v2/analyzer/Dockerfile
+++ b/v2/analyzer/Dockerfile
@@ -15,7 +15,7 @@ RUN pip install retry
 
 RUN mkdir ~/python-pycurl-openssl && \
     cd ~/python-pycurl-openssl && \
-    curl https://dl.bintray.com/pycurl/pycurl/pycurl-7.43.0.2.tar.gz -L -O && \
+    pip download pycurl==7.43.0.2 && \
     tar -xzvf pycurl-7.43.0.2.tar.gz && \
     cd pycurl-7.43.0.2 && \
     python2.7 setup.py --with-ssl install


### PR DESCRIPTION
Hi!

This is now a dead link and an image can no longer be built from this Dockerfile.
https://dl.bintray.com/pycurl/pycurl/pycurl-7.43.0.2.tar.gz
(JFrog is ending hosting resources in their bintray platform)

looks like something similar to this would work instead but still testing
pip download pycurl==7.43.0.2 
